### PR TITLE
Add CAA record to certbot-manual-authenticator.sh

### DIFF
--- a/certbot-manual-authenticator.sh
+++ b/certbot-manual-authenticator.sh
@@ -21,4 +21,4 @@ no-hosts" > /tmp/certbot-dnsmasq.conf
 fi
 
 echo "txt-record=_acme-challenge.$CERTBOT_DOMAIN,\"$CERTBOT_VALIDATION\"" >> /tmp/certbot-dnsmasq.conf
-dnsmasq -C /tmp/certbot-dnsmasq.conf
+dnsmasq --dns-rr="$CERTBOT_DOMAIN,257,000569737375656C657473656E63727970742E6F7267" -C /tmp/certbot-dnsmasq.conf


### PR DESCRIPTION
Let's Encrypt now checks the CAA record of the domain name.

A `--dns-rr` option has been added to the `dnsmasq` command in `certbot-manual-authenticator.sh`, with an hex value allowing letsencrypt.org as an issuer (value generated using [https://sslmate.com/caa/](https://sslmate.com/caa/))